### PR TITLE
Test expiration

### DIFF
--- a/idempotency_header_middleware/backends/base.py
+++ b/idempotency_header_middleware/backends/base.py
@@ -45,3 +45,11 @@ class Backend(ABC):
         key stored in 'store_idempotency_key'.
         """
         ...
+
+    @abstractmethod
+    async def expire_idempotency_keys(self) -> None:
+        """
+        Remove any expired idempotency keys to avoid returning 409s
+        after the response expires.
+        """
+        ...

--- a/idempotency_header_middleware/backends/base.py
+++ b/idempotency_header_middleware/backends/base.py
@@ -3,10 +3,9 @@ from typing import Optional
 
 from starlette.responses import Response
 
-DEFAULT_EXPIRY = 60 * 60 * 24
 
 class Backend(ABC):
-    expiry: Optional[int] = DEFAULT_EXPIRY
+    expiry: Optional[int] = 60 * 60 * 24
 
     @abstractmethod
     async def get_stored_response(self, idempotency_key: str) -> Optional[Response]:

--- a/idempotency_header_middleware/backends/base.py
+++ b/idempotency_header_middleware/backends/base.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 from starlette.responses import Response
 
+DEFAULT_EXPIRY = 60 * 60 * 24
 
 class Backend(ABC):
-    expiry: Optional[int] = 60 * 60 * 24
+    expiry: Optional[int] = DEFAULT_EXPIRY
 
     @abstractmethod
     async def get_stored_response(self, idempotency_key: str) -> Optional[Response]:

--- a/idempotency_header_middleware/backends/memory.py
+++ b/idempotency_header_middleware/backends/memory.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Set
 
 from starlette.responses import JSONResponse
 
-from idempotency_header_middleware.backends.base import Backend
+from idempotency_header_middleware.backends.base import Backend, DEFAULT_EXPIRY
 
 
 @dataclass()
@@ -19,7 +19,7 @@ class MemoryBackend(Backend):
     The backend is mainly here for local development or testing.
     """
 
-    expiry: Optional[int] = 60 * 60 * 24
+    expiry: Optional[int] = DEFAULT_EXPIRY
 
     response_store: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     keys: Set[str] = field(default_factory=set)

--- a/idempotency_header_middleware/backends/memory.py
+++ b/idempotency_header_middleware/backends/memory.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Set
 
 from starlette.responses import JSONResponse
 
-from idempotency_header_middleware.backends.base import Backend, DEFAULT_EXPIRY
+from idempotency_header_middleware.backends.base import Backend
 
 
 @dataclass()
@@ -19,7 +19,7 @@ class MemoryBackend(Backend):
     The backend is mainly here for local development or testing.
     """
 
-    expiry: Optional[int] = DEFAULT_EXPIRY
+    expiry: Optional[int] = 60 * 60 * 24
 
     response_store: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     keys: Set[str] = field(default_factory=set)

--- a/idempotency_header_middleware/backends/redis.py
+++ b/idempotency_header_middleware/backends/redis.py
@@ -58,7 +58,7 @@ class RedisBackend(Backend):
         """
         Store an idempotency key header value in a sortedset.
         """
-        return not bool(await self.redis.zadd(self.KEYS_KEY, {idempotency_key: time.time() + self.expiry},))
+        return not bool(await self.redis.zadd(self.KEYS_KEY, {idempotency_key: time.time() + float(self.expiry or 0)},))
 
     async def clear_idempotency_key(self, idempotency_key: str) -> None:
         """

--- a/idempotency_header_middleware/backends/redis.py
+++ b/idempotency_header_middleware/backends/redis.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
-from idempotency_header_middleware.backends.base import Backend, DEFAULT_EXPIRY
+from idempotency_header_middleware.backends.base import Backend
 
 
 @dataclass()
@@ -15,7 +15,7 @@ class RedisBackend(Backend):
         redis: Redis,
         keys_key: str = 'idempotency-key-keys',
         response_key: str = 'idempotency-key-responses',
-        expiry: int = DEFAULT_EXPIRY,
+        expiry: int = 60 * 60 * 24,
     ):
         self.redis = redis
         self.KEYS_KEY = keys_key
@@ -49,7 +49,7 @@ class RedisBackend(Backend):
         await self.redis.set(payload_key, json.dumps(payload))
         await self.redis.set(status_code_key, status_code)
 
-        if self.expiry >= 0:
+        if self.expiry:
             await self.redis.expire(payload_key, self.expiry)
             await self.redis.expire(status_code_key, self.expiry)
 

--- a/idempotency_header_middleware/backends/redis.py
+++ b/idempotency_header_middleware/backends/redis.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
-from idempotency_header_middleware.backends.base import Backend
+from idempotency_header_middleware.backends.base import Backend, DEFAULT_EXPIRY
 
 
 @dataclass()
@@ -15,7 +15,7 @@ class RedisBackend(Backend):
         redis: Redis,
         keys_key: str = 'idempotency-key-keys',
         response_key: str = 'idempotency-key-responses',
-        expiry: int = 60 * 60 * 24,
+        expiry: int = DEFAULT_EXPIRY,
     ):
         self.redis = redis
         self.KEYS_KEY = keys_key
@@ -49,7 +49,7 @@ class RedisBackend(Backend):
         await self.redis.set(payload_key, json.dumps(payload))
         await self.redis.set(status_code_key, status_code)
 
-        if self.expiry:
+        if self.expiry >= 0:
             await self.redis.expire(payload_key, self.expiry)
             await self.redis.expire(status_code_key, self.expiry)
 

--- a/idempotency_header_middleware/middleware.py
+++ b/idempotency_header_middleware/middleware.py
@@ -49,6 +49,7 @@ class IdempotencyHeaderMiddleware:
             response = JSONResponse(payload, 422)
             return await response(scope, receive, send)
 
+        await self.backend.expire_idempotency_keys()
         if stored_response := await self.backend.get_stored_response(idempotency_key):
             stored_response.headers[self.replay_header_key] = 'true'
             return await stored_response(scope, receive, send)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from starlette.responses import (
     StreamingResponse,
 )
 
-from idempotency_header_middleware.backends.base import DEFAULT_EXPIRY
 from idempotency_header_middleware.backends.redis import RedisBackend
 from idempotency_header_middleware.middleware import IdempotencyHeaderMiddleware
 
@@ -71,22 +70,13 @@ method_configs = {
 def method_config(request):
     return request.param
 
-expirations = {
-    'default': DEFAULT_EXPIRY,
-    'immediately': 0,
-}
-
-@pytest.fixture(scope='session', ids=expirations.keys(), params=expirations.values())
-def expiry(request):
-    return request.param
-
 
 @pytest.fixture(scope='session', autouse=True)
-def app_with_middleware(method_config, expiry):
+def app_with_middleware(method_config):
     app.add_middleware(
         IdempotencyHeaderMiddleware,
         enforce_uuid4_formatting=True,
-        backend=RedisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True), expiry=expiry),
+        backend=RedisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True)),
         applicable_methods=method_config['setting'],
     )
     yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from starlette.responses import (
     StreamingResponse,
 )
 
+from idempotency_header_middleware.backends.base import DEFAULT_EXPIRY
 from idempotency_header_middleware.backends.redis import RedisBackend
 from idempotency_header_middleware.middleware import IdempotencyHeaderMiddleware
 
@@ -70,13 +71,22 @@ method_configs = {
 def method_config(request):
     return request.param
 
+expirations = {
+    'default': DEFAULT_EXPIRY,
+    'immediately': 0,
+}
+
+@pytest.fixture(scope='session', ids=expirations.keys(), params=expirations.values())
+def expiry(request):
+    return request.param
+
 
 @pytest.fixture(scope='session', autouse=True)
-def app_with_middleware(method_config):
+def app_with_middleware(method_config, expiry):
     app.add_middleware(
         IdempotencyHeaderMiddleware,
         enforce_uuid4_formatting=True,
-        backend=RedisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True)),
+        backend=RedisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True), expiry=expiry),
         applicable_methods=method_config['setting'],
     )
     yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ from idempotency_header_middleware.middleware import IdempotencyHeaderMiddleware
 
 logger = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.fixture(autouse=True, scope='session')
 def _configure_logging():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,9 +7,7 @@ import pytest
 from idempotency_header_middleware.backends.base import Backend
 from idempotency_header_middleware.backends.memory import MemoryBackend
 from idempotency_header_middleware.backends.redis import RedisBackend
-from tests.conftest import dummy_response
-
-pytestmark = pytest.mark.asyncio
+from tests.conftest import dummy_response, pytestmark # noqa: F401
 
 base_methods = [
     'get_stored_response',

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@ base_methods = [
     'store_response_data',
     'store_idempotency_key',
     'clear_idempotency_key',
+    'expire_idempotency_keys',
 ]
 
 
@@ -26,11 +27,13 @@ def test_base_backend():
 
 
 redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+backends = {"redis": RedisBackend(redis), "memory": MemoryBackend()}
 
-
-@pytest.mark.parametrize('backend', [RedisBackend(redis, expiry=1), MemoryBackend(expiry=1)])
-async def test_backend(backend: Backend):
+@pytest.mark.parametrize('backend', backends.values(), ids=backends.keys())
+@pytest.mark.parametrize('expiry', [0, 1])
+async def test_backend(backend: Backend, expiry: int):
     assert issubclass(backend.__class__, Backend)
+    backend.expiry = expiry
 
     # Test setting and clearing key
     id_ = str(uuid4())
@@ -52,4 +55,22 @@ async def test_backend(backend: Backend):
     # Test fetching data after expiry
     await backend.store_response_data(id_, dummy_response, 201)
     await asyncio.sleep(1)
-    assert (await backend.get_stored_response(id_)) is None
+    stored_response = await backend.get_stored_response(id_)
+    if expiry:
+        assert stored_response is None
+    else:
+        assert stored_response is not None
+
+    # Test storing idempotency key after expiry
+    id_ = str(uuid4())
+    already_existed = await backend.store_idempotency_key(id_)
+    assert already_existed is False
+    already_existed = await backend.store_idempotency_key(id_)
+    assert already_existed is True
+    await asyncio.sleep(1)
+    await backend.expire_idempotency_keys()
+    already_existed = await backend.store_idempotency_key(id_)
+    if expiry:
+        assert already_existed is False
+    else:
+        assert already_existed is True

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -5,9 +5,7 @@ from uuid import uuid4
 import pytest
 from httpx import AsyncClient, Response
 
-from tests.conftest import app, dummy_response
-
-pytestmark = pytest.mark.asyncio
+from tests.conftest import app, dummy_response, pytestmark
 
 http_call = Callable[..., Awaitable[Response]]
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -5,8 +5,7 @@ from uuid import uuid4
 import pytest
 from httpx import AsyncClient, Response
 
-from tests.conftest import app, dummy_response, pytestmark
-
+from tests.conftest import app, dummy_response, pytestmark # noqa: F401
 http_call = Callable[..., Awaitable[Response]]
 
 


### PR DESCRIPTION
I don't think expiration works as intended (or at least as I would expect it).

The response keys are correctly expired, but nothing is ever removed from the idempotency keys set. This has two consequences:

- once a response key expires, requests using the same idempotency key will return 409 forever
- the idempotency keys set grows without bound

Instead, I would expect expiration to also apply to the idempotency keys set. Once the expiration window has passed, a new request with the same idempotency key should issue a new request.

This commit only introduces the tests without implementing a solution. For MemoryBackend, I'd propose storing the expiry alongside the idempotency key. For RedisBackend, I'd propose something along the lines of https://github.com/redis/redis/issues/135#issuecomment-2361996 using a sorted set to purge expired idempotency keys. But I wanted to run the change by you before taking action on either approach.